### PR TITLE
Bump wrapper package versions and add Reveal SDK peer dependency

### DIFF
--- a/packages/wrappers-angular/package.json
+++ b/packages/wrappers-angular/package.json
@@ -1,10 +1,10 @@
 {
   "name": "reveal-sdk-wrappers-angular",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "peerDependencies": {
     "@angular/common": ">=18.1.0",
     "@angular/core": ">=18.1.0",
-    "reveal-sdk-wrappers": ">=0.2.2"
+    "reveal-sdk-wrappers": ">=0.3.0"
   },
   "sideEffects": false
 }

--- a/packages/wrappers-react/package.json
+++ b/packages/wrappers-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reveal-sdk-wrappers-react",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",
@@ -12,6 +12,6 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "reveal-sdk-wrappers": ">=0.2.2"
+    "reveal-sdk-wrappers": ">=0.3.0"
   }
 }

--- a/packages/wrappers/package.json
+++ b/packages/wrappers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reveal-sdk-wrappers",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "type": "module",
   "main": "./index.umd.js",
   "module": "./index.js",
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "lit": "^3.2.1"
+  },
+  "peerDependencies": {
+    "reveal-sdk": "^2.0.0"
   }
 }


### PR DESCRIPTION
Updates `reveal-sdk-wrappers`, `reveal-sdk-wrappers-angular`, and `reveal-sdk-wrappers-react` to version `0.3.0`.

The core `reveal-sdk-wrappers` package now specifies `reveal-sdk` ^2.0.0 as a peer dependency. The Angular and React wrappers are updated to peer depend on `reveal-sdk-wrappers` ^0.3.0.
